### PR TITLE
fixed build error in dist job when using the icon task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -112,6 +112,7 @@ module.exports = function(grunt) {
 	grunt.registerTask('dist', [
 		'env:dist',
 		'clean',
+        'icons',
 		'build',
 		'copy:dist'
 	]);


### PR DESCRIPTION
added the 'icons' task to the dist job, so that it doesn't fail when the user created icons before in the dev environment.